### PR TITLE
add lea-sea relationship

### DIFF
--- a/models/oneroster_1_1/or1_1__orgs.sql
+++ b/models/oneroster_1_1/or1_1__orgs.sql
@@ -37,7 +37,7 @@ leas_formatted as (
         lea_name as "name",
         'district' as "type",
         lea_id as "identifier",
-        gen_sourced_id('sea') as "parentSourcedId",
+        {{ gen_sourced_id('sea') }} as "parentSourcedId",
         {{ gen_natural_key('lea') }} as "metadata.edu.natural_key",
         tenant_code
     from leas

--- a/models/oneroster_1_1/or1_1__orgs.sql
+++ b/models/oneroster_1_1/or1_1__orgs.sql
@@ -37,8 +37,7 @@ leas_formatted as (
         lea_name as "name",
         'district' as "type",
         lea_id as "identifier",
-        {# gen_sourced_id('sea') as "parentSourcedId", #}
-        null::string as "parentSourcedId", --tmp: pending update in edu_edfi_source
+        gen_sourced_id('sea') as "parentSourcedId",
         {{ gen_natural_key('lea') }} as "metadata.edu.natural_key",
         tenant_code
     from leas


### PR DESCRIPTION
Adds the parent-child relationship between LEAs and SEAs in the Orgs table.

This change is only compatible with edu_edfi_source 0.3.0 and above, due to a name change on SEA tables.

Safe to release as a new version, provided implementing projects do not adopt it until they have updated their EDU packages.